### PR TITLE
Fix dark mode hook bug

### DIFF
--- a/frontend/src/Components/hooks/useDarkMode.jsx
+++ b/frontend/src/Components/hooks/useDarkMode.jsx
@@ -3,9 +3,11 @@ import { useEffect, useState } from 'react';
 export default function UseDarkMode() {
   // 1. initial state
   const [enabled, setEnabled] = useState(() => {
-    localStorage.theme === 'dark' ||
+    return (
+      localStorage.theme === 'dark' ||
       (!('theme' in localStorage) &&
-        window.matchMedia('(prefer-color-scheme: dark)').matches);
+        window.matchMedia('(prefers-color-scheme: dark)').matches)
+    );
   });
 
   // 2. side effect: keep DOM + storage in sync


### PR DESCRIPTION
## Summary
- fix typo and missing return in `useDarkMode`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840026e3e4c832aa9ea24fcce7368ec